### PR TITLE
feat: :zap: Support for Precommit Parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Optional Flags:
 However, it aims to have following capabilities in the near future:
 
 - [x] Add support to parse pre-existing `requirements.txt` files and selectively update dependencies.
-- [ ] Parsing precommit hooks for dev dependencies.
+- [x] Parsing precommit hooks for dev dependencies.
 - [ ] Support for loading packages from Conda instead of pip.
 - [ ] Add support for specifying virtual environment using `-e` flag.
 

--- a/core/known-precommits.json
+++ b/core/known-precommits.json
@@ -1,0 +1,7 @@
+{
+    "black": true,
+    "isort": true,
+    "flake8": true,
+    "nbstripout": true,
+    "docformatter": true
+}

--- a/core/precommit.go
+++ b/core/precommit.go
@@ -1,0 +1,94 @@
+package core
+
+import (
+	"embed"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"os"
+
+	"gopkg.in/yaml.v2"
+)
+
+//go:embed known-precommits.json
+var p embed.FS
+
+type preCommit struct {
+	Repos []struct {
+		Repo  string `yaml:"repo"`
+		Rev   string `yaml:"rev"`
+		Hooks []struct {
+			ID string `yaml:"id"`
+		} `yaml:"hooks"`
+	} `yaml:"repos"`
+}
+
+func onPyPi(arg string) bool {
+	url := "https://pypi.python.org/pypi/" + arg
+	resp, err := http.Get(url)
+	if err != nil {
+		return false
+	}
+	if resp.StatusCode == 200 {
+		return true
+	}
+	return false
+}
+
+func getKnownPrecommits() (map[string]bool, error) {
+	knownPrecommits := make(map[string]bool)
+	preCommits, err := p.ReadFile("known-precommits.json")
+	if err != nil {
+		return nil, err
+	}
+	err = json.Unmarshal(preCommits, &knownPrecommits)
+	if err != nil {
+		return nil, err
+	}
+	return knownPrecommits, nil
+}
+
+func GetDevDependencies(path string) ([]string, error) {
+	precommitPath := path + "/.pre-commit-config.yaml"
+	// Check if pre-commit file exists
+	if _, err := os.Stat(precommitPath); os.IsNotExist(err) {
+		return nil, nil
+	}
+	source, err := ioutil.ReadFile(precommitPath)
+	if err != nil {
+		return nil, err
+	}
+	// Parse the yaml file.
+	var data preCommit
+	err = yaml.Unmarshal(source, &data)
+	if err != nil {
+		return nil, err
+	}
+	knownPrecommits, err := getKnownPrecommits()
+	if err != nil {
+		return nil, err
+	}
+	parsedPrecommits := []string{}
+	// Loop through the repos.
+	for _, repo := range data.Repos {
+		// Ignore if repo is original precommit repo
+		if repo.Repo == "https://github.com/pre-commit/pre-commit-hooks" {
+			continue
+		}
+		// Loop through the hooks.
+		for _, hook := range repo.Hooks {
+			// Check if the hook is known.
+			if knownPrecommits[hook.ID] {
+				// Append to parsedPrecommits
+				parsedPrecommits = append(parsedPrecommits, hook.ID)
+			} else {
+				// Check if the hook is on PyPi
+				if onPyPi(hook.ID) {
+					// Append to parsedPrecommits
+					parsedPrecommits = append(parsedPrecommits, hook.ID)
+				}
+			}
+		}
+	}
+	return parsedPrecommits, nil
+}

--- a/go.mod
+++ b/go.mod
@@ -8,4 +8,5 @@ require (
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/spf13/cobra v1.4.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
+	gopkg.in/yaml.v2 v2.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -14,4 +14,5 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=


### PR DESCRIPTION
`preppy` can now parse .pre-commit-config.yaml and check if the imports are present on Pypi or in known list, if they are, it treats them as normal imports.